### PR TITLE
Add MkDocs documentation site with GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,69 @@
+name: Deploy MkDocs
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin mkdocs-awesome-pages-plugin mkdocs-include-dir-to-nav
+
+      - name: Build site
+        run: mkdocs build --clean --strict
+
+      - name: Setup Pages
+        if: github.ref == 'refs/heads/main'
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Claude Code local memory
+CLAUDE.local.md
+
+# macOS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# MkDocs
+site/
+.cache/
+
+# Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-# Claude Code local memory
+# Claude Code memory
+CLAUDE.md
 CLAUDE.local.md
 
 # macOS

--- a/index.md
+++ b/index.md
@@ -1,0 +1,116 @@
+# AI-Assisted Development Adoption Playbook
+
+## Preface: A Transformation Guide for Development Teams
+
+### Why This Playbook Exists
+
+The software development landscape is undergoing its most significant transformation since the introduction of high-level programming languages. AI-assisted development isn't just another tool in the developer's toolkit—it's a fundamental shift in how we conceive, create, and maintain software systems.
+
+This playbook emerged from real-world observations of teams navigating this transformation. It synthesizes hard-won insights from organizations that have successfully adopted AI-native practices, as well as cautionary tales from those who stumbled along the way. Whether you're a developer curious about AI's potential, a team lead guiding your group through change, or an executive making strategic technology decisions, this playbook provides practical guidance for your journey.
+
+### What Makes This Different
+
+Unlike theoretical frameworks or vendor-specific documentation, this playbook focuses on the human and organizational aspects of AI adoption. Yes, we discuss tools and techniques, but more importantly, we explore:
+
+- How teams actually change their practices
+- What resistance looks like and how to address it
+- Which metrics matter and which are vanity
+- How to avoid common pitfalls that seem successful at first
+- What organizational structures support sustainable adoption
+
+This is not a technology manual—it's a transformation guide written by practitioners for practitioners.
+
+## Getting Started
+
+!!! tip "Quick Start"
+    Ready to begin? Here's your first step:
+    
+    1. **Assess where you are**: Use the maturity model in [Part 3: Enterprise Adoption](Part-03-Enterprise-Adoption.md)
+    2. **Choose your path**: Select the reading path that matches your role below
+    3. **Start experimenting**: Pick one practice from [Part 5: Development Practices](Part-05-Development-Practices.md) to try this week
+    4. **Share your learning**: Discuss with your team what you discover
+
+### Reading Paths by Role
+
+=== "Individual Developers"
+
+    Start with **Part 1: Foundations** to understand the historical context and philosophical underpinnings. Then jump to **Part 5: Development Practices** for practical techniques you can apply immediately.
+
+    **Reading Path:**
+    
+    1. [Part 1: Foundations](Part-01-Foundations.md) (context)
+    2. [Part 5: Development Practices](Part-05-Development-Practices.md) (practical skills)
+    3. [Part 6: Antipatterns](Part-06-Antipatterns.md) (what to avoid)
+    4. Other parts as needed
+
+=== "Team Leads"
+
+    Begin with **Part 4: Team Implementation Patterns** to understand the human dynamics of adoption. Review **Part 6: Antipatterns** with your team to establish shared awareness.
+
+    **Reading Path:**
+    
+    1. [Part 4: Team Implementation Patterns](Part-04-Team-Implementation.md) (team dynamics)
+    2. [Part 6: Antipatterns](Part-06-Antipatterns.md) (shared awareness)
+    3. [Part 7: Coordination and Governance](Part-07-Coordination-and-Governance.md) (process design)
+    4. [Part 9: Enablement and Education](Part-09-Enablement-and-Education.md) (skill building)
+
+=== "Architects"
+
+    Start with **Part 2: Systems Thinking** to understand the fundamental shifts required. **Part 8: Technical Architecture** provides detailed architectural patterns.
+
+    **Reading Path:**
+    
+    1. [Part 2: Systems Thinking](Part-02-Systems-Thinking.md) (conceptual framework)
+    2. [Part 8: Technical Architecture](Part-08-Technical-Architecture.md) (implementation patterns)
+    3. [Part 3: Enterprise Adoption](Part-03-Enterprise-Adoption.md) (organizational impact)
+    4. [Part 7: Coordination and Governance](Part-07-Coordination-and-Governance.md) (technical governance)
+
+=== "Executives"
+
+    Begin with **Part 3: Enterprise Adoption Framework** for strategic perspectives. **Part 10: The Path Forward** provides a vision of where the industry is heading.
+
+    **Reading Path:**
+    
+    1. [Part 3: Enterprise Adoption Framework](Part-03-Enterprise-Adoption.md) (strategy)
+    2. [Part 10: The Path Forward](Part-10-The-Path-Forward.md) (future vision)
+    3. [Part 6: Antipatterns](Part-06-Antipatterns.md) (risk awareness)
+    4. [Part 4: Team Implementation Patterns](Part-04-Team-Implementation.md) (change management)
+
+## Key Principles
+
+As you use this playbook, keep these principles in mind:
+
+1. **Start Small, Learn Fast**: Don't try to transform everything at once
+2. **Measure What Matters**: Focus on outcomes, not activity
+3. **Address the Human Side**: Technology is easy; people are hard
+4. **Maintain Critical Thinking**: AI augments judgment, doesn't replace it
+5. **Share Knowledge**: Learn from others, contribute back
+
+## What Success Looks Like
+
+Teams successfully using this playbook report:
+
+- **3-10x productivity improvements** without sacrificing quality
+- **Higher developer satisfaction** through elimination of mundane tasks
+- **Better software architecture** through AI-assisted design
+- **Faster onboarding** with AI-powered knowledge systems
+- **Sustainable practices** that improve over time
+
+But perhaps more importantly, they report a fundamental shift in how they think about software development—from individual craftsmanship to collaborative intelligence, from static systems to adaptive ones, from scarcity thinking to abundance mindsets.
+
+## Quick Reference: Key Concepts
+
+- **Operational Moat vs Technical Moat**: Building competitive advantage through superior practices and processes, not just technology
+- **AI as Augmentation, Not Replacement**: Enhancing human capabilities rather than substituting for them
+- **Roguelike Development Methodology**: Rapid iteration, learning from failure, and continuous experimentation
+- **Consent vs Consensus Decision-Making**: Moving faster by seeking no objections rather than full agreement
+- **Token Economics**: Managing the cost and efficiency of AI interactions
+- **Model Context Protocol (MCP)**: Standardized tool orchestration for AI systems
+- **Self-Healing Development Systems**: Building resilient processes that improve automatically
+- **Living Documentation**: Documentation that evolves with the codebase
+- **Forked Metrics and Retrospectives**: Separate tracks for AI and human contributions
+- **The Learning Imperative**: Continuous skill development in the AI era
+
+---
+
+*"The best way to predict the future is to invent it. The best way to invent it is together."*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,108 @@
+site_name: AI-Assisted Development Adoption Playbook
+site_description: A practical guide for teams and organizations adopting AI-native development practices
+site_author: Foray Consulting
+site_url: https://forayconsulting.github.io/AI-Assisted-Dev-Adoption-Playbook
+
+repo_name: forayconsulting/AI-Assisted-Dev-Adoption-Playbook
+repo_url: https://github.com/forayconsulting/AI-Assisted-Dev-Adoption-Playbook
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.path
+    - navigation.top
+    - search.highlight
+    - search.share
+    - toc.follow
+    - content.code.copy
+  palette:
+    - scheme: default
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+plugins:
+  - search
+  - awesome-pages
+  - include_dir_to_nav:
+      file_name_as_title: true
+      sort_file: true
+      sort_directory: true
+      flat: false
+      recurse: true
+      include_empty_dir: false
+  - git-revision-date-localized:
+      enable_creation_date: true
+      type: datetime
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Foundations:
+    - "Part 1: Foundations": Part-01-Foundations.md
+    - "Part 2: Systems Thinking": Part-02-Systems-Thinking.md
+    - "Part 3: Enterprise Adoption": Part-03-Enterprise-Adoption.md
+  - Implementation:
+    - "Part 4: Team Implementation": Part-04-Team-Implementation.md
+    - "Part 5: Development Practices": Part-05-Development-Practices.md
+  - Governance & Risk:
+    - "Part 6: Antipatterns": Part-06-Antipatterns.md
+    - "Part 7: Coordination and Governance": Part-07-Coordination-and-Governance.md
+  - Architecture & Future:
+    - "Part 8: Technical Architecture": Part-08-Technical-Architecture.md
+    - "Part 9: Enablement and Education": Part-09-Enablement-and-Education.md
+    - "Part 10: The Path Forward": Part-10-The-Path-Forward.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/forayconsulting/AI-Assisted-Dev-Adoption-Playbook
+  analytics:
+    feedback:
+      title: Was this page helpful?
+      ratings:
+        - icon: material/emoticon-happy-outline
+          name: This page was helpful
+          data: 1
+          note: >-
+            Thanks for your feedback!
+        - icon: material/emoticon-sad-outline
+          name: This page could be improved
+          data: 0
+          note: >-
+            Thanks for your feedback! Help us improve this page by
+            <a href="https://github.com/forayconsulting/AI-Assisted-Dev-Adoption-Playbook/issues/new" target="_blank" rel="noopener">opening an issue</a>.
+
+copyright: |
+  &copy; 2024 Foray Consulting. 
+  <a href="#__consent">Change cookie settings</a>


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automated MkDocs deployment to GitHub Pages
- Configure Material theme with dark/light mode toggle and enhanced navigation
- Set up navigation structure matching the playbook's organization
- Add Mermaid diagram support for visual documentation
- Include directory-to-nav plugin for automatic navigation generation
- Create responsive homepage with role-based reading paths
- Update .gitignore to exclude build artifacts and Claude memory files

## Features Added
- **GitHub Actions CI/CD**: Automatic deployment on push to main
- **Material Theme**: Modern, responsive design with dark/light mode
- **Enhanced Navigation**: Tabbed navigation with sections and search
- **Mermaid Diagrams**: Support for flowcharts and diagrams
- **Auto Navigation**: Automatic generation from directory structure
- **Role-based Paths**: Tailored reading recommendations by user role

## Test Plan
- [ ] Verify GitHub Actions workflow builds successfully
- [ ] Test site deployment to GitHub Pages
- [ ] Confirm all navigation links work correctly
- [ ] Validate Mermaid diagram rendering
- [ ] Check responsive design on mobile/desktop